### PR TITLE
Update the Airflow version

### DIFF
--- a/integrity_tests/requirements.txt
+++ b/integrity_tests/requirements.txt
@@ -1,3 +1,3 @@
 pytest
-airflow
+apache-airflow
 coverage


### PR DESCRIPTION
Hi @danielvdende,

I would like to update the dependencies. `airflow` is the old package name, since 1.8.0 Airflow has to be installed using `apache-airflow`.

Cheers, Fokko