### PR TITLE
specify pip version to ensure docker build success

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -49,7 +49,7 @@ RUN set -ex \
     && locale-gen \
     && update-locale LANG=en_US.UTF-8 LC_ALL=en_US.UTF-8 \
     && useradd -ms /bin/bash -d ${AIRFLOW_HOME} airflow \
-    && python -m pip install -U pip setuptools wheel \
+    && python -m pip install -U pip==9.0.1 setuptools wheel \
     && pip install Cython \
     && pip install pytz \
     && pip install pyOpenSSL \


### PR DESCRIPTION
Dear developer,

I recently read your article on Medium and learned a lot about testing! When I cloned the repo and tried to build the docker image, I got the following error:
```
Collecting apache-airflow[celery,crypto,hive,jdbc,postgres]==1.8.2
  Downloading https://files.pythonhosted.org/packages/f1/83/a5fc6da0ced7c06f080b9b423b3483a926e7a387892a9013ec12229a0a89/apache-airflow-1.8.2.tar.gz (2.3MB)
    Complete output from command python setup.py egg_info:
    Traceback (most recent call last):
      File "<string>", line 1, in <module>
      File "/tmp/pip-install-4f97arrv/apache-airflow/setup.py", line 302, in <module>
        do_setup()
      File "/tmp/pip-install-4f97arrv/apache-airflow/setup.py", line 198, in do_setup
        check_previous()
      File "/tmp/pip-install-4f97arrv/apache-airflow/setup.py", line 105, in check_previous
        in pip.get_installed_distributions()])
    AttributeError: module 'pip' has no attribute 'get_installed_distributions'
```

When I looked up the error message, I found the solution here in `paulclarkaranz`'s comment: https://github.com/Miserlou/Zappa/issues/1471

Which is to specify pip's version to 9.0.1. After I did that, I was able to build the image, hence I created this pull request. 