### PR TITLE
Test for DAG cycles

### DIFF
--- a/integrity_tests/test_dag_integrity.py
+++ b/integrity_tests/test_dag_integrity.py
@@ -21,9 +21,9 @@ def test_dag_integrity(dag_file):
     mod_spec = importlib.util.spec_from_file_location(module_name, module_path)
     module = importlib.util.module_from_spec(mod_spec)
     mod_spec.loader.exec_module(module)
-    
+
     dag_objects = [var for var in vars(module).values() if isinstance(var, af_models.DAG)]
     assert dag_objects
-    
+
     for dag in dag_objects:
         dag.test_cycle()

--- a/integrity_tests/test_dag_integrity.py
+++ b/integrity_tests/test_dag_integrity.py
@@ -22,7 +22,7 @@ def test_dag_integrity(dag_file):
     module = importlib.util.module_from_spec(mod_spec)
     mod_spec.loader.exec_module(module)
     
-    dag_objects = [var for var in vars(module).values() if isinstance(var, airflow_models.DAG)]
+    dag_objects = [var for var in vars(module).values() if isinstance(var, af_models.DAG)]
     assert dag_objects
     
     for dag in dag_objects:

--- a/integrity_tests/test_dag_integrity.py
+++ b/integrity_tests/test_dag_integrity.py
@@ -21,6 +21,9 @@ def test_dag_integrity(dag_file):
     mod_spec = importlib.util.spec_from_file_location(module_name, module_path)
     module = importlib.util.module_from_spec(mod_spec)
     mod_spec.loader.exec_module(module)
-    assert any(
-        isinstance(var, af_models.DAG)
-        for var in vars(module).values())
+    
+    dag_objects = [var for var in vars(module).values() if isinstance(var, airflow_models.DAG)]
+    assert dag_objects
+    
+    for dag in dag_objects:
+        dag.test_cycle()


### PR DESCRIPTION
At some point the DAG cycle test was removed from the DAG initialization and as a result the DAG integrity test was green even when a DAG contained cycles. This PR explicitly checks for cycles in DAGs.