### PR TITLE
Fix broken CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,5 @@
 language: python
+dist: xenial
 python:
   - "3.6"
 jobs:
@@ -17,6 +18,8 @@ jobs:
         - echo "prd" > dags/environment.conf
         - coverage run -m pytest integrity_tests/*
     - stage: mock_pipeline_tests
+      before_install: 
+        - source travis_java_install.sh
       install:
         - pip install -r mock_pipeline_tests/requirements.txt
       script:

--- a/travis_java_install.sh
+++ b/travis_java_install.sh
@@ -1,0 +1,25 @@
+#!/bin/bash
+
+# borrowed from: https://github.com/dpkp/kafka-python/blob/master/travis_java_install.sh
+
+# Kafka requires Java 8 in order to work properly. However, TravisCI's Ubuntu
+# 16.04 ships with Java 11 and Java can't be set with `jdk` when python is
+# selected as language. Ubuntu 14.04 does not work due to missing python 3.7
+# support on TravisCI which does have Java 8 as default.
+
+# show current JAVA_HOME and java version
+echo "Current JAVA_HOME: $JAVA_HOME"
+echo "Current java -version:"
+which java
+java -version
+
+echo "Updating JAVA_HOME"
+# change JAVA_HOME to Java 8
+export JAVA_HOME=/usr/lib/jvm/java-1.8.0-openjdk-amd64
+
+echo "Updating PATH"
+export PATH=${PATH/\/usr\/local\/lib\/jvm\/openjdk11\/bin/$JAVA_HOME\/bin}
+
+echo "New java -version"
+which java
+java -version


### PR DESCRIPTION
Travis CI was broken as the default JDK was now Java 11, which won't work with Spark (yet). This patches it up, using some inspiration from https://github.com/dpkp/kafka-python